### PR TITLE
Fix exit handling in MIDI listener

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -154,9 +154,12 @@ class MidiHandler
         {
             midiIn.Stop();
             Console.WriteLine("MIDI 输入监听已停止。");
+            e.Cancel = true;
         };
 
-        while (true) { }
+        Console.WriteLine("按任意键退出...");
+        Console.ReadKey();
+        midiIn.Stop();
     }
 
     private static void OnMidiMessageReceived(object sender, MidiInMessageEventArgs e)


### PR DESCRIPTION
## Summary
- prevent infinite loop in `MidiHandler.Start`
- ensure the MIDI listener stops on cancel or key press

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457b898bf08328b9104c303977bf22